### PR TITLE
Add option to reverse tab ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,18 +289,20 @@ auto_pytabs_tab_title_template = "Python {min_version}+"  # optional
 # auto_pytabs_no_cache = True  # disabled file system caching
 # auto_pytabs_compat_mode = True  # enable compatibility mode
 # auto_pytabs_default_tab = "lowest"  # Pre-select the tab with the lowest version
+# auto_pytabs_reverse_order = True  # reverse the order of tabs to highest > lowest
 ```
 
 #### Available configuration options
 
-| Name                             | Default                   | Description                                            |
-| -------------------------------- | ------------------------- | ------------------------------------------------------ |
-| `auto_pytabs_min_version`        | `(3, 7)`                  | Minimum python version to generate code for            |
-| `auto_pytabs_max_version`        | `(3, 7)`                  | Maximum python version to generate code for            |
-| `auto_pytabs_tab_title_template` | `"Python {min_version}+"` | Template for tab titles                                |
-| `auto_pytabs_no_cache`           | `False`                   | Disable file system caching                            |
-| `auto_pytabs_compat_mode`        | `False`                   | Enable [compatibility mode](#compatibility-mode)       |
-| `auto_pytabs_default_tab`        | `highest`                 | Either `highest` or `lowest`. Version tab to preselect |
+| Name                             | Default                   | Description                                                                |
+| -------------------------------- | ------------------------- | -------------------------------------------------------------------------- |
+| `auto_pytabs_min_version`        | `(3, 7)`                  | Minimum python version to generate code for                                |
+| `auto_pytabs_max_version`        | `(3, 7)`                  | Maximum python version to generate code for                                |
+| `auto_pytabs_tab_title_template` | `"Python {min_version}+"` | Template for tab titles                                                    |
+| `auto_pytabs_no_cache`           | `False`                   | Disable file system caching                                                |
+| `auto_pytabs_compat_mode`        | `False`                   | Enable [compatibility mode](#compatibility-mode)                           |
+| `auto_pytabs_default_tab`        | `highest`                 | Either `highest` or `lowest`. Version tab to preselect                     |
+| `auto_pytabs_reverse_order`      | `False`                   | Reverse the order of tabs. Default is to go from lowest to highest version |
 
 <h3 id="sphinx-examples">Examples</h3>
 

--- a/README.md
+++ b/README.md
@@ -78,17 +78,19 @@ plugins:
       tab_title_template: "Python {min_version}+"  # optional
       no_cache: false  # optional
       default_tab: "highest"  # optional
+      reverse_order: false  # optional
 ```
 
 *Available configuration options*
 
-| Name                 | Default                   | Description                                      |
-| -------------------- | ------------------------- | ------------------------------------------------ |
-| `min_version`        | `(3, 7)`                  | Minimum python version                           |
-| `max_version`        | `(3, 7)`                  | Maximum python version                           |
-| `tab_title_template` | `"Python {min_version}+"` | Template for tab titles                          |
-| `no_cache`           | `False`                   | Disable file system caching                      |
-| `default_tab`        | `highest`                 | (`highest` or `lowest`) Version tab to preselect |
+| Name                 | Default                   | Description                                                                |
+| -------------------- | ------------------------- | -------------------------------------------------------------------------- |
+| `min_version`        | `(3, 7)`                  | Minimum python version                                                     |
+| `max_version`        | `(3, 7)`                  | Maximum python version                                                     |
+| `tab_title_template` | `"Python {min_version}+"` | Template for tab titles                                                    |
+| `no_cache`           | `False`                   | Disable file system caching                                                |
+| `default_tab`        | `highest`                 | (`highest` or `lowest`) Version tab to preselect                           |
+| `reverse_order`      | `False`                   | Reverse the order of tabs. Default is to go from lowest to highest version |
 
 #### Markdown extension
 
@@ -102,6 +104,8 @@ md = markdown.Markdown(
             "min_version": "3.7",  # optional
             "max_version": "3.11",  # optional
             "tab_title_template": "Python {min_version}+",  # optional
+            "default_tab": "highest",  # optional
+            "reverse_order": False,  # optional
         }
     },
 )
@@ -109,12 +113,13 @@ md = markdown.Markdown(
 
 *Available configuration options*
 
-| Name                 | Default                   | Description                                      |
-| -------------------- | ------------------------- | ------------------------------------------------ |
-| `min_version`        | `(3, 7)`                  | Minimum python version to generate code for      |
-| `max_version`        | `(3, 7)`                  | Maximum python version to generate code for      |
-| `tab_title_template` | `"Python {min_version}+"` | Template for tab titles                          |
-| `default_tab`        | `highest`                 | (`highest` or `lowest`) Version tab to preselect |
+| Name                 | Default                   | Description                                                                |
+| -------------------- | ------------------------- | -------------------------------------------------------------------------- |
+| `min_version`        | `(3, 7)`                  | Minimum python version to generate code for                                |
+| `max_version`        | `(3, 7)`                  | Maximum python version to generate code for                                |
+| `tab_title_template` | `"Python {min_version}+"` | Template for tab titles                                                    |
+| `default_tab`        | `highest`                 | (`highest` or `lowest`) Version tab to preselect                           |
+| `reverse_order`      | `False`                   | Reverse the order of tabs. Default is to go from lowest to highest version |
 
 ### Differences between the mkdocs plugin and markdown extension
 

--- a/auto_pytabs/mkdocs_plugin.py
+++ b/auto_pytabs/mkdocs_plugin.py
@@ -18,6 +18,7 @@ class PluginConfig(Config):  # type: ignore[no-untyped-call]
     tab_title_template = config_options.Type(str, default="Python {min_version}+")
     no_cache = config_options.Type(bool, default=False)
     default_tab = config_options.Choice(["highest", "lowest"], default="highest")
+    reverse_order = config_options.Type(bool, default=False)
 
 
 class AutoPyTabsPlugin(BasePlugin[PluginConfig]):  # type: ignore[no-untyped-call]
@@ -37,6 +38,7 @@ class AutoPyTabsPlugin(BasePlugin[PluginConfig]):  # type: ignore[no-untyped-cal
                     "tab_title_template": self.config.tab_title_template,
                     "cache": self.cache,
                     "default_tab": self.config.default_tab,
+                    "reverse_order": self.config.reverse_order,
                 }
             }
         )

--- a/auto_pytabs/sphinx_ext.py
+++ b/auto_pytabs/sphinx_ext.py
@@ -25,7 +25,9 @@ if TYPE_CHECKING:
     from sphinx.environment import BuildEnvironment
 
 
-def indent(text: str | list[str], indent_char: str = " ", level: int = 4) -> list[str]:
+def indent(
+    text: str | Iterable[str], indent_char: str = " ", level: int = 4
+) -> list[str]:
     lines = text.splitlines() if isinstance(text, str) else text
     return list((indent_char * level) + line for line in lines)
 
@@ -35,7 +37,7 @@ def _render_directive(
     name: str,
     argument: str = "",
     options: dict[str, Any] | None = None,
-    body: str | list[str],
+    body: str | Iterable[str],
 ) -> list[str]:
     directive = [f".. {name}:: {argument}"]
     if options:
@@ -92,6 +94,9 @@ class UpgradeMixin(SphinxDirective):
         ]
 
         tab_set_body = []
+        if self.config["auto_pytabs_reverse_order"]:
+            versioned_code = dict(reversed(versioned_code.items()))
+
         for version, code in versioned_code.items():
             version_string = f"{version[0]}.{version[1]}"
             code_block = _render_directive(
@@ -228,6 +233,7 @@ def setup(app: Sphinx) -> dict[str, bool | str]:
     app.add_config_value("auto_pytabs_no_cache", default=False, rebuild="html")
     app.add_config_value("auto_pytabs_compat_mode", default=False, rebuild="html")
     app.add_config_value("auto_pytabs_default_tab", default="highest", rebuild="html")
+    app.add_config_value("auto_pytabs_reverse_order", default=False, rebuild="html")
 
     app.connect("config-inited", on_config_inited)
     app.connect("build-finished", on_build_finished)

--- a/test/md_ext_test_data/upgrade_out_default_highest_reversed.md
+++ b/test/md_ext_test_data/upgrade_out_default_highest_reversed.md
@@ -1,0 +1,22 @@
+===+ "Python 3.10+"
+    ```python foo="bar"
+    
+    def bar(baz: str | None) -> set[str]:
+        ...
+    ```
+
+=== "Python 3.9+"
+    ```python foo="bar"
+    from typing import Optional
+    
+    def bar(baz: Optional[str]) -> set[str]:
+        ...
+    ```
+
+=== "Python 3.7+"
+    ```python foo="bar"
+    from typing import Set, Optional
+    
+    def bar(baz: Optional[str]) -> Set[str]:
+        ...
+    ```

--- a/test/md_ext_test_data/upgrade_out_default_lowest_reversed.md
+++ b/test/md_ext_test_data/upgrade_out_default_lowest_reversed.md
@@ -1,0 +1,22 @@
+=== "Python 3.10+"
+    ```python foo="bar"
+    
+    def bar(baz: str | None) -> set[str]:
+        ...
+    ```
+
+=== "Python 3.9+"
+    ```python foo="bar"
+    from typing import Optional
+    
+    def bar(baz: Optional[str]) -> set[str]:
+        ...
+    ```
+
+===+ "Python 3.7+"
+    ```python foo="bar"
+    from typing import Set, Optional
+    
+    def bar(baz: Optional[str]) -> Set[str]:
+        ...
+    ```

--- a/test/sphinx_ext_test_data/tabs_all_versions_reversed.xml
+++ b/test/sphinx_ext_test_data/tabs_all_versions_reversed.xml
@@ -1,0 +1,113 @@
+<document source="index">
+    <section ids="index" names="index">
+        <title>
+            Index
+        <section ids="code-block" names="code-block">
+            <title>
+                code-block
+            <container classes="sd-tab-set" design_component="tab-set" is_div="True">
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="True">
+                    <rubric classes="sd-tab-label" sync_id="3.10">
+                        Python 3.10+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id1" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                def foo(x: dict[str, str] | list[str]) -> list[int] | None:
+                                    pass
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="False">
+                    <rubric classes="sd-tab-label" sync_id="3.9">
+                        Python 3.9+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id2" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                from typing import Union, Optional
+                                
+                                def foo(x: Union[dict[str, str], list[str]]) -> Optional[list[int]]:
+                                    pass
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="False">
+                    <rubric classes="sd-tab-label" sync_id="3.7">
+                        Python 3.7+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id3" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                from typing import Dict, Union, List, Optional
+                                
+                                def foo(x: Union[Dict[str, str], List[str]]) -> Optional[List[int]]:
+                                    pass
+        <section ids="code-block-no-upgrade" names="code-block\ no\ upgrade">
+            <title>
+                code-block no upgrade
+            <container classes="literal-block-wrapper" ids="id4" literal_block="True">
+                <caption>
+                    test caption
+                <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                    from typing import Dict, Union, List, Optional
+                    
+                    def foo(x: Union[Dict[str, str], List[str]]) -> Optional[List[int]]:
+                        pass
+        <section ids="code-block-non-python" names="code-block\ non-python">
+            <title>
+                code-block non-python
+            <literal_block force="False" highlight_args="{}" language="javascript" xml:space="preserve">
+                const x = "hello"
+        <section ids="code-block-no-language" names="code-block\ no\ language">
+            <title>
+                code-block no language
+            <literal_block force="False" highlight_args="{}" language="default" xml:space="preserve">
+                this is something
+        <section ids="literalinclude" names="literalinclude">
+            <title>
+                literalinclude
+            <container classes="sd-tab-set" design_component="tab-set" is_div="True">
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="True">
+                    <rubric classes="sd-tab-label" sync_id="3.10">
+                        Python 3.10+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id5" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                def foo(x: dict[str, str] | list[str]) -> list[int] | None:
+                                    pass
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="False">
+                    <rubric classes="sd-tab-label" sync_id="3.9">
+                        Python 3.9+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id6" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                from typing import Union, Optional
+                                
+                                
+                                def foo(x: Union[dict[str, str], list[str]]) -> Optional[list[int]]:
+                                    pass
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="False">
+                    <rubric classes="sd-tab-label" sync_id="3.7">
+                        Python 3.7+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id7" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                from typing import Dict, Union, List, Optional
+                                
+                                
+                                def foo(x: Union[Dict[str, str], List[str]]) -> Optional[List[int]]:
+                                    pass
+        <section ids="literalinclude-non-python" names="literalinclude\ non-python">
+            <title>
+                literalinclude non-python
+            <literal_block force="False" highlight_args="{'linenostart': 1}" language="javascript" source="example.js" xml:space="preserve">
+                const foo = "bar"
+        <section ids="literalinclude-no-language" names="literalinclude\ no\ language">
+            <title>
+                literalinclude no language
+            <literal_block force="False" highlight_args="{'linenostart': 1}" source="example.js" xml:space="preserve">
+                const foo = "bar"

--- a/test/sphinx_ext_test_data/tabs_default_tab_highest_reversed.xml
+++ b/test/sphinx_ext_test_data/tabs_default_tab_highest_reversed.xml
@@ -1,0 +1,113 @@
+<document source="index">
+    <section ids="index" names="index">
+        <title>
+            Index
+        <section ids="code-block" names="code-block">
+            <title>
+                code-block
+            <container classes="sd-tab-set" design_component="tab-set" is_div="True">
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="True">
+                    <rubric classes="sd-tab-label" sync_id="3.10">
+                        Python 3.10+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id1" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                def foo(x: dict[str, str] | list[str]) -> list[int] | None:
+                                    pass
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="False">
+                    <rubric classes="sd-tab-label" sync_id="3.9">
+                        Python 3.9+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id2" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                from typing import Union, Optional
+                                
+                                def foo(x: Union[dict[str, str], list[str]]) -> Optional[list[int]]:
+                                    pass
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="False">
+                    <rubric classes="sd-tab-label" sync_id="3.7">
+                        Python 3.7+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id3" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                from typing import Dict, Union, List, Optional
+                                
+                                def foo(x: Union[Dict[str, str], List[str]]) -> Optional[List[int]]:
+                                    pass
+        <section ids="code-block-no-upgrade" names="code-block\ no\ upgrade">
+            <title>
+                code-block no upgrade
+            <container classes="literal-block-wrapper" ids="id4" literal_block="True">
+                <caption>
+                    test caption
+                <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                    from typing import Dict, Union, List, Optional
+                    
+                    def foo(x: Union[Dict[str, str], List[str]]) -> Optional[List[int]]:
+                        pass
+        <section ids="code-block-non-python" names="code-block\ non-python">
+            <title>
+                code-block non-python
+            <literal_block force="False" highlight_args="{}" language="javascript" xml:space="preserve">
+                const x = "hello"
+        <section ids="code-block-no-language" names="code-block\ no\ language">
+            <title>
+                code-block no language
+            <literal_block force="False" highlight_args="{}" language="default" xml:space="preserve">
+                this is something
+        <section ids="literalinclude" names="literalinclude">
+            <title>
+                literalinclude
+            <container classes="sd-tab-set" design_component="tab-set" is_div="True">
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="True">
+                    <rubric classes="sd-tab-label" sync_id="3.10">
+                        Python 3.10+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id5" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                def foo(x: dict[str, str] | list[str]) -> list[int] | None:
+                                    pass
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="False">
+                    <rubric classes="sd-tab-label" sync_id="3.9">
+                        Python 3.9+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id6" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                from typing import Union, Optional
+                                
+                                
+                                def foo(x: Union[dict[str, str], list[str]]) -> Optional[list[int]]:
+                                    pass
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="False">
+                    <rubric classes="sd-tab-label" sync_id="3.7">
+                        Python 3.7+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id7" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                from typing import Dict, Union, List, Optional
+                                
+                                
+                                def foo(x: Union[Dict[str, str], List[str]]) -> Optional[List[int]]:
+                                    pass
+        <section ids="literalinclude-non-python" names="literalinclude\ non-python">
+            <title>
+                literalinclude non-python
+            <literal_block force="False" highlight_args="{'linenostart': 1}" language="javascript" source="example.js" xml:space="preserve">
+                const foo = "bar"
+        <section ids="literalinclude-no-language" names="literalinclude\ no\ language">
+            <title>
+                literalinclude no language
+            <literal_block force="False" highlight_args="{'linenostart': 1}" source="example.js" xml:space="preserve">
+                const foo = "bar"

--- a/test/sphinx_ext_test_data/tabs_default_tab_lowest_reversed.xml
+++ b/test/sphinx_ext_test_data/tabs_default_tab_lowest_reversed.xml
@@ -1,0 +1,113 @@
+<document source="index">
+    <section ids="index" names="index">
+        <title>
+            Index
+        <section ids="code-block" names="code-block">
+            <title>
+                code-block
+            <container classes="sd-tab-set" design_component="tab-set" is_div="True">
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="False">
+                    <rubric classes="sd-tab-label" sync_id="3.10">
+                        Python 3.10+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id1" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                def foo(x: dict[str, str] | list[str]) -> list[int] | None:
+                                    pass
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="False">
+                    <rubric classes="sd-tab-label" sync_id="3.9">
+                        Python 3.9+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id2" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                from typing import Union, Optional
+                                
+                                def foo(x: Union[dict[str, str], list[str]]) -> Optional[list[int]]:
+                                    pass
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="True">
+                    <rubric classes="sd-tab-label" sync_id="3.7">
+                        Python 3.7+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id3" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                from typing import Dict, Union, List, Optional
+                                
+                                def foo(x: Union[Dict[str, str], List[str]]) -> Optional[List[int]]:
+                                    pass
+        <section ids="code-block-no-upgrade" names="code-block\ no\ upgrade">
+            <title>
+                code-block no upgrade
+            <container classes="literal-block-wrapper" ids="id4" literal_block="True">
+                <caption>
+                    test caption
+                <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                    from typing import Dict, Union, List, Optional
+                    
+                    def foo(x: Union[Dict[str, str], List[str]]) -> Optional[List[int]]:
+                        pass
+        <section ids="code-block-non-python" names="code-block\ non-python">
+            <title>
+                code-block non-python
+            <literal_block force="False" highlight_args="{}" language="javascript" xml:space="preserve">
+                const x = "hello"
+        <section ids="code-block-no-language" names="code-block\ no\ language">
+            <title>
+                code-block no language
+            <literal_block force="False" highlight_args="{}" language="default" xml:space="preserve">
+                this is something
+        <section ids="literalinclude" names="literalinclude">
+            <title>
+                literalinclude
+            <container classes="sd-tab-set" design_component="tab-set" is_div="True">
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="False">
+                    <rubric classes="sd-tab-label" sync_id="3.10">
+                        Python 3.10+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id5" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                def foo(x: dict[str, str] | list[str]) -> list[int] | None:
+                                    pass
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="False">
+                    <rubric classes="sd-tab-label" sync_id="3.9">
+                        Python 3.9+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id6" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                from typing import Union, Optional
+                                
+                                
+                                def foo(x: Union[dict[str, str], list[str]]) -> Optional[list[int]]:
+                                    pass
+                <container classes="sd-tab-item" design_component="tab-item" is_div="True" selected="True">
+                    <rubric classes="sd-tab-label" sync_id="3.7">
+                        Python 3.7+
+                    <container classes="sd-tab-content" design_component="tab-content" is_div="True">
+                        <container classes="literal-block-wrapper" ids="id7" literal_block="True">
+                            <caption>
+                                test caption
+                            <literal_block force="False" highlight_args="{}" language="python" xml:space="preserve">
+                                from typing import Dict, Union, List, Optional
+                                
+                                
+                                def foo(x: Union[Dict[str, str], List[str]]) -> Optional[List[int]]:
+                                    pass
+        <section ids="literalinclude-non-python" names="literalinclude\ non-python">
+            <title>
+                literalinclude non-python
+            <literal_block force="False" highlight_args="{'linenostart': 1}" language="javascript" source="example.js" xml:space="preserve">
+                const foo = "bar"
+        <section ids="literalinclude-no-language" names="literalinclude\ no\ language">
+            <title>
+                literalinclude no language
+            <literal_block force="False" highlight_args="{'linenostart': 1}" source="example.js" xml:space="preserve">
+                const foo = "bar"

--- a/test/test_markdown_ext.py
+++ b/test/test_markdown_ext.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from auto_pytabs.markdown_ext import UpgradePreprocessor
+
+if TYPE_CHECKING:
+    from pytest_regressions.file_regression import FileRegressionFixture
 
 TEST_DATA_DIR = Path("test/md_ext_test_data")
 
@@ -15,68 +19,86 @@ def preprocessor() -> UpgradePreprocessor:
     )
 
 
-def get_test_data(name: str) -> tuple[str, str]:
+def get_test_data(name: str) -> tuple[list[str], Path]:
     in_file = TEST_DATA_DIR / f"{name}_in.md"
     out_file = TEST_DATA_DIR / f"{name}_out.md"
-    return in_file.read_text(), out_file.read_text()
+    return in_file.read_text().splitlines(), out_file
 
 
-def test_upgrade_single_version(file_regression):
-    source, expected_output = get_test_data("upgrade_single")
+def test_upgrade_single_version(file_regression: FileRegressionFixture):
+    source, expected_output_path = get_test_data("upgrade_single")
     preprocessor = UpgradePreprocessor(
         min_version="3.9", max_version="3.11", default_tab_strategy="highest"
     )
 
-    output = "\n".join(preprocessor.run(source.splitlines()))
-    assert output == expected_output
+    output = "\n".join(preprocessor.run(source))
+    file_regression.check(output, fullpath=expected_output_path)
 
 
+@pytest.mark.parametrize(
+    "reverse_order", [False, True], ids=lambda item: f"reverse:{item}"
+)
 @pytest.mark.parametrize("default_tab_strategy", ["highest", "lowest"])
-def test_upgrade(default_tab_strategy: str):
+def test_upgrade(
+    default_tab_strategy: str,
+    reverse_order: bool,
+    file_regression: FileRegressionFixture,
+):
     source = TEST_DATA_DIR.joinpath("upgrade_in.md").read_text()
-    expected_output = TEST_DATA_DIR.joinpath(
-        f"upgrade_out_default_{default_tab_strategy}.md"
-    ).read_text()
+    file_stem = f"upgrade_out_default_{default_tab_strategy}"
+    if reverse_order:
+        file_stem += "_reversed"
+    expected_output = TEST_DATA_DIR.joinpath(file_stem + ".md")
+
     preprocessor = UpgradePreprocessor(
-        min_version="3.7", max_version="3.11", default_tab_strategy=default_tab_strategy
+        min_version="3.7",
+        max_version="3.11",
+        default_tab_strategy=default_tab_strategy,
+        reverse_order=reverse_order,
     )
-
+    file_regression.force_regen = True
     output = "\n".join(preprocessor.run(source.splitlines()))
-    assert output == expected_output
+    file_regression.check(output, fullpath=expected_output)
 
 
-def test_upgrade_custom_tab_title():
+def test_upgrade_custom_tab_title(file_regression: FileRegressionFixture):
     preprocessor = UpgradePreprocessor(
         min_version="3.7",
         max_version="3.11",
         tab_title_template="Python {min_version} and above",
         default_tab_strategy="highest",
     )
-    source, expected_output = get_test_data("custom_tab_title")
+    source, expected_output_path = get_test_data("custom_tab_title")
 
-    output = "\n".join(preprocessor.run(source.splitlines()))
-    assert output == expected_output
-
-
-def test_nested_tabs(preprocessor: UpgradePreprocessor):
-    source, expected_output = get_test_data("nested_tabs")
-
-    output = "\n".join(preprocessor.run(source.splitlines()))
-    assert output == expected_output
+    output = "\n".join(preprocessor.run(source))
+    file_regression.check(output, fullpath=expected_output_path)
 
 
-def test_disable_block(preprocessor: UpgradePreprocessor):
-    source, expected_output = get_test_data("disable_block")
+def test_nested_tabs(
+    preprocessor: UpgradePreprocessor, file_regression: FileRegressionFixture
+):
+    source, expected_output_path = get_test_data("nested_tabs")
 
-    output = "\n".join(preprocessor.run(source.splitlines()))
-    assert output == expected_output
+    output = "\n".join(preprocessor.run(source))
+    file_regression.check(output, fullpath=expected_output_path)
 
 
-def test_disable_section(preprocessor: UpgradePreprocessor):
-    source, expected_output = get_test_data("disable_section")
+def test_disable_block(
+    preprocessor: UpgradePreprocessor, file_regression: FileRegressionFixture
+):
+    source, expected_output_path = get_test_data("disable_block")
 
-    output = "\n".join(preprocessor.run(source.splitlines()))
-    assert output == expected_output
+    output = "\n".join(preprocessor.run(source))
+    file_regression.check(output, fullpath=expected_output_path)
+
+
+def test_disable_section(
+    preprocessor: UpgradePreprocessor, file_regression: FileRegressionFixture
+):
+    source, expected_output_path = get_test_data("disable_section")
+
+    output = "\n".join(preprocessor.run(source))
+    file_regression.check(output, fullpath=expected_output_path)
 
 
 def test_ignore_fenced_block(preprocessor: UpgradePreprocessor):


### PR DESCRIPTION
Add a configuration option to reverse the ordering of version tabs.

Added configuration options are:

- `reverse_order` for the markdown extension and MkDocs plugin
- `auto_pytabs_reverse_order` for the Sphinx extension.

Setting either of these to `True` will change the order of the version tabs from `low > high` to `high > low`.