### PR TITLE
Support newer ruff versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,8 +30,8 @@ repos:
           exclude: "test"
           args: ["--strict"]
           additional_dependencies:
-            - types-docutils
-            - sphinx
+            - "types-docutils==0.19.1.1"
+            - "sphinx==5.3.0"
             - types-markdown
-            - mkdocs
+            - "mkdocs==1.4.2"
             - pymdown-extensions

--- a/auto_pytabs/core.py
+++ b/auto_pytabs/core.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, NamedTuple
 
 RUFF_BASE_ARGS = [
     "ruff",
+    "check",
     "--no-cache",
     "--fix",
     "--quiet",


### PR DESCRIPTION
Using `ruff` with the implicit `check` command is deprecated in newer versions